### PR TITLE
nixdoc: init at 3.0.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1715447595,
-        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,10 @@
 {
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  };
-
-  outputs =
-    { self, nixpkgs, ... }:
+  outputs = { self, ... }:
     let
       forAllSystems = self.lib.genAttrs self.lib.systems.flakeExposed;
     in
     {
       lib = import ./lib;
-
-      nixPackages = forAllSystems (system: nixpkgs.legacyPackages.${system});
 
       auxPackages = forAllSystems (system:
         (
@@ -41,6 +34,8 @@
             import ./pkgs/top-level/default.nix { localSystem = system; }
         )
       );
+
+      legacyPackages = forAllSystems (system: import ./. { inherit system; });
 
       # To test, run nix build .#tests.x86_64-linux.release
       tests = forAllSystems (system: {

--- a/pkgs/by-name/ni/nixdoc/default.nix
+++ b/pkgs/by-name/ni/nixdoc/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  darwin,
+}: let
+  version = "3.0.2";
+in
+  rustPlatform.buildRustPackage {
+    pname = "nixdoc";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "nix-community";
+      repo = "nixdoc";
+      rev = "v${version}";
+      sha256 = "sha256-V3MAvbdYk3DL064UYcJE9HmwfQBwpMxVXWiAKX6honA=";
+    };
+
+    cargoHash = "sha256-RFxTjLiJCEc42Mb8rcayOFHkYk2GfpgsO3+hAaRwHgs=";
+
+    buildInputs = lib.optionals stdenv.isDarwin [darwin.Security];
+
+    meta = {
+      description = "Generate documentation for Nix functions";
+      mainProgram = "nixdoc";
+      homepage = "https://github.com/nix-community/nixdoc";
+      license = lib.licenses.gpl3;
+      # maintainers = with lib.maintainers; [ infinisil hsjobeki ];
+      platforms = lib.platforms.unix;
+    };
+  }


### PR DESCRIPTION
This removes the upstream dependancy, and adds the nixdoc package. Let me know if you think its better to break this into 2 PRs.