### PR TITLE
fetchFromGitHub: force re-fetch when rev changes

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -27,6 +27,7 @@ lib.makeOverridable (
 , # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
   # needed for netrcPhase
   netrcImpureEnvVars ? []
+, passthru ? {}
 , meta ? {}
 , allowedRequisites ? null
 }:
@@ -103,7 +104,7 @@ stdenvNoCC.mkDerivation {
 
   inherit preferLocalBuild meta allowedRequisites;
 
-  passthru = {
+  passthru = passthru // {
     gitRepoUrl = url;
   };
 }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -3,7 +3,7 @@
 lib.makeOverridable (
 { owner, repo, rev
 , name ? null # Override with null to use the default value
-, pname ? "source-${owner}-${repo}"
+, pname ? "source-${githubBase}-${owner}-${repo}"
 , fetchSubmodules ? false, leaveDotGit ? null
 , deepClone ? false, private ? false, forceFetchGit ? false
 , sparseCheckout ? []

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,7 +1,9 @@
 { lib, fetchgit, fetchzip }:
 
 lib.makeOverridable (
-{ owner, repo, rev, name ? "source"
+{ owner, repo, rev
+, name ? null # Override with null to use the default value
+, pname ? "source-${owner}-${repo}"
 , fetchSubmodules ? false, leaveDotGit ? null
 , deepClone ? false, private ? false, forceFetchGit ? false
 , sparseCheckout ? []
@@ -11,6 +13,8 @@ lib.makeOverridable (
 }@args:
 
 let
+  name = if args.name or null != null then args.name
+  else "${pname}-${rev}";
 
   position = (if args.meta.description or null != null
     then builtins.unsafeGetAttrPos "description" args.meta


### PR DESCRIPTION
Since we have yet to hit the ground running, we have a golden opportunity to fix some of those long-standing issues in upstream that don't get fixed to avoid disturbing the whole project. Specifically, this is the fact that `fetchFromGitHub` currently outputs a FOD with a very generic name. As a result, if a maintainer changes a version number but forgets about the output hash, it may not get caught. Error messages are also less useful. If we can fix that we will have much better DX moving forward.

To illustrate: I tried to rebuild `nixdoc` to see if it was working and I immediately caught a stale hash.

Based on https://github.com/NixOS/nixpkgs/pull/294068