### PR TITLE
AAAAAASomeThingsFailToEvaluate: drop

### DIFF
--- a/pkgs/top-level/base-packages.nix
+++ b/pkgs/top-level/base-packages.nix
@@ -104,14 +104,6 @@ with pkgs;
 
   stringsWithDeps = lib.stringsWithDeps;
 
-  ### Evaluating the entire Nixpkgs naively will fail, make failure fast
-  AAAAAASomeThingsFailToEvaluate = throw ''
-    Please be informed that this pseudo-package is not the only part
-    of Nixpkgs that fails to evaluate. You should not evaluate
-    entire Nixpkgs without some special measures to handle failing
-    packages, like using pkgs/top-level/release-attrpaths-superset.nix.
-  '';
-
   tests = callPackages ../test { };
 
   # These are used when buiding compiler-rt / libgcc, prior to building libc.


### PR DESCRIPTION
This thing was introduced due to the size of Nixpkgs. It does not currently — and hopefully will never — make sense in Auxolotl Core.