### PR TITLE
fetchFromGitLab: force re-fetch when rev changes

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -2,7 +2,9 @@
 
 lib.makeOverridable (
 # gitlab example
-{ owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
+{ owner, repo, rev, protocol ? "https", domain ? "gitlab.com", group ? null
+, pname ? lib.concatStringsSep "-" ([ "source" domain ] ++ (lib.optional (group != null) group) ++ [ owner repo ])
+, name ? "${pname}-${rev}"
 , fetchSubmodules ? false, leaveDotGit ? false
 , deepClone ? false, forceFetchGit ? false
 , sparseCheckout ? []


### PR DESCRIPTION
There are a few instances of `fetchFromGitLab` in the repo, for instance `gtk-doc.src`.

My primary goal when writing this was changing the output derivation following #11. This is doable with a lot less diff in `fetchFromGitLab`, but it's worth asking whether both fetchers should be different and why. I think a lot of the divergence comes from years of random commits rather than from design.