### PR TITLE
fetchFromSavannah: force re-fetch when rev changes

### DIFF
--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -2,7 +2,7 @@
 
 lib.makeOverridable (
 # cgit example, snapshot support is optional in cgit
-{ repo, rev, name ? "source"
+{ repo, rev, name ? "source-savannah.gnu.org-${repo}-${rev}"
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;


### PR DESCRIPTION
In the spirit of #11 

Example: `gnulib.src`